### PR TITLE
Bug fix : Always check all connectedNodes of current Node

### DIFF
--- a/src/component/Graph/Bipartite/Result/Result.tsx
+++ b/src/component/Graph/Bipartite/Result/Result.tsx
@@ -156,22 +156,39 @@ export const BipartiteResult = ({ ...props }: BipartiteResultProps) => {
     graphToProcess: Map<string, GraphValue>,
     nodeToSearch: string
   ): boolean => {
-    let connectedNodes: GraphValue | undefined;
-    let connectedNodesName: string = "";
+    const connectedNodesArr: Array<{
+      nodeName: string;
+      nodeValue: GraphValue;
+    }> = [];
 
+    /* Get and check every connected nodes */
     graphToProcess.forEach((nodeValue, nodeName) => {
       if (nodeValue.edge.has(nodeToSearch)) {
-        connectedNodes = nodeValue;
-        connectedNodesName = nodeName;
+        connectedNodesArr.push({ nodeValue, nodeName });
+      }
+    });
+    console.log("debug connectedNodesArr : ", connectedNodesArr);
+
+    /* Checking every connected Node and see if they are connected to another nodes */
+    let isConnected = false;
+    connectedNodesArr.forEach((connectedNode) => {
+      if (connectedNode.nodeValue.edge.size === 1) {
+        /* It means we need to check the the connectivity of the connected node again */
+        const isConnectedNodeOfConnectedNode = isConnectedNode(
+          graphToProcess,
+          connectedNode.nodeName
+        );
+        if (isConnectedNodeOfConnectedNode) {
+          isConnected = true;
+        }
+      }
+
+      if (!!connectedNode.nodeValue && connectedNode.nodeValue.edge.size > 1) {
+        isConnected = true;
       }
     });
 
-    if (connectedNodes?.edge.size === 1) {
-      /* It means we need to check the the connectivity of the connected node again */
-      return isConnectedNode(graphToProcess, connectedNodesName);
-    }
-
-    return !!connectedNodes && connectedNodes.edge.size > 1;
+    return isConnected;
   };
 
   let totalDisconnectedNode = 0;


### PR DESCRIPTION
# Overview
Currently there is a missing checking on one of the leg for this sample
<img width="500" alt="image" src="https://user-images.githubusercontent.com/2855979/205518589-0faa33fb-5756-4ab1-8e38-e9a0c584b9d7.png">

# Fixes
Currently fixing it by adding the checker to run for all connectedNodes
